### PR TITLE
Resolve Next.js Version Detection Issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
-  "buildCommand": "cd frontend && npm run build",
-  "devCommand": "cd frontend && npm run dev",
-  "installCommand": "cd frontend && npm install",
+  "buildCommand": "npm run build",
+  "devCommand": "npm run dev",
+  "installCommand": "npm install",
   "framework": "nextjs",
-  "outputDirectory": "frontend/.next"
+  "outputDirectory": ".next",
+  "rootDirectory": "frontend"
 }


### PR DESCRIPTION
Added rootDirectory setting to vercel.json to point to the frontend directory where package.json with Next.js dependency is located. This resolves the "No Next.js version detected" error on Vercel deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)