### PR TITLE
Add Next.js API rewrite for backend proxying

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -70,7 +70,7 @@ The backend is already configured to deploy to Render using the `render.yaml` fi
 
    | Variable | Value | Description |
    |----------|-------|-------------|
-   | `NEXT_PUBLIC_BACKEND_URL` | `https://your-app.onrender.com` | Your Render backend URL |
+   | `NEXT_PUBLIC_BACKEND_URL` | `https://your-app.onrender.com` | Your Render backend URL. Used to proxy `/api/*` calls through Next.js so browser requests stay same-origin for SSE streams. |
    | `NODE_ENV` | `production` | Node environment |
 
    Optional (for Sentry):

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -19,6 +19,33 @@ const config = {
     locales: ["en"],
     defaultLocale: "en",
   },
+
+  async rewrites() {
+    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+    if (!backendUrl) {
+      return [];
+    }
+
+    const normalizedBackendUrl = backendUrl.endsWith("/")
+      ? backendUrl.slice(0, -1)
+      : backendUrl;
+
+    const isLocalBackend = /https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(?::\d+)?$/i.test(
+      normalizedBackendUrl,
+    );
+
+    if (isLocalBackend) {
+      return [];
+    }
+
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${normalizedBackendUrl}/api/:path*`,
+      },
+    ];
+  },
 };
 export default withSentryConfig(config, {
 // For all available options, see:


### PR DESCRIPTION
## Summary
- add a Next.js rewrite that proxies `/api/*` requests to the configured backend URL when running off localhost
- document that the frontend relies on `NEXT_PUBLIC_BACKEND_URL` to keep SSE traffic same-origin via the new rewrite

## Testing
- not run (interactive ESLint prompt prevents automation)


------
https://chatgpt.com/codex/tasks/task_e_68fe6dd0f1d8832397a6bd4811b1b83c