### PR TITLE
Handle conversations with missing document metadata

### DIFF
--- a/backend/app/chat/engine.py
+++ b/backend/app/chat/engine.py
@@ -87,9 +87,11 @@ def fetch_and_read_document(
 
 
 def build_description_for_document(document: DocumentSchema) -> str:
-    if DocumentMetadataKeysEnum.SEC_DOCUMENT in document.metadata_map:
+    metadata_map = document.metadata_map or {}
+
+    if DocumentMetadataKeysEnum.SEC_DOCUMENT in metadata_map:
         sec_metadata = SecDocumentMetadata.model_validate(
-            document.metadata_map[DocumentMetadataKeysEnum.SEC_DOCUMENT]
+            metadata_map[DocumentMetadataKeysEnum.SEC_DOCUMENT]
         )
         time_period = (
             f"{sec_metadata.year} Q{sec_metadata.quarter}"
@@ -237,7 +239,8 @@ async def get_chat_engine(
     api_query_engine_tools = [
         get_api_query_engine_tool(doc, callback_manager)
         for doc in conversation.documents
-        if DocumentMetadataKeysEnum.SEC_DOCUMENT in doc.metadata_map
+        if doc.metadata_map
+        and DocumentMetadataKeysEnum.SEC_DOCUMENT in doc.metadata_map
     ]
 
     quantitative_question_engine = SubQuestionQueryEngine.from_defaults(

--- a/backend/app/chat/utils.py
+++ b/backend/app/chat/utils.py
@@ -6,11 +6,13 @@ from app.schema import (
 
 
 def build_title_for_document(document: DocumentSchema) -> str:
-    if DocumentMetadataKeysEnum.SEC_DOCUMENT not in document.metadata_map:
+    metadata_map = document.metadata_map or {}
+
+    if DocumentMetadataKeysEnum.SEC_DOCUMENT not in metadata_map:
         return "No Title Document"
 
     sec_metadata = SecDocumentMetadata.model_validate(
-        document.metadata_map[DocumentMetadataKeysEnum.SEC_DOCUMENT]
+        metadata_map[DocumentMetadataKeysEnum.SEC_DOCUMENT]
     )
     time_period = (
         f"{sec_metadata.year} Q{sec_metadata.quarter}"

--- a/backend/tests/app/chat/test_utils.py
+++ b/backend/tests/app/chat/test_utils.py
@@ -1,0 +1,45 @@
+import pytest
+
+from app.chat.utils import build_title_for_document
+from app.schema import (
+    Document,
+    DocumentMetadataKeysEnum,
+    SecDocumentMetadata,
+    SecDocumentTypeEnum,
+)
+
+
+def test_build_title_for_document_without_metadata():
+    document = Document(url="https://example.com", metadata_map=None)
+
+    assert build_title_for_document(document) == "No Title Document"
+
+
+def test_build_title_for_document_with_sec_metadata():
+    metadata = SecDocumentMetadata(
+        company_name="Example Corp",
+        company_ticker="EX",
+        doc_type=SecDocumentTypeEnum.TEN_K,
+        year=2024,
+    )
+    document = Document(
+        url="https://example.com",
+        metadata_map={DocumentMetadataKeysEnum.SEC_DOCUMENT: metadata.model_dump()},
+    )
+
+    assert (
+        build_title_for_document(document)
+        == "Example Corp (EX) 10-K (2024)"
+    )
+
+
+def test_build_description_for_document_without_metadata():
+    pytest.importorskip("llama_index")
+    from app.chat.engine import build_description_for_document
+
+    document = Document(url="https://example.com", metadata_map=None)
+
+    assert (
+        build_description_for_document(document)
+        == "A document containing useful information that the user pre-selected to discuss with the assistant."
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent
+BACKEND_ROOT = ROOT_DIR.parent
+
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))


### PR DESCRIPTION
## Summary
- avoid crashes in chat helpers when a conversation document lacks SEC metadata
- only register quantitative tools for documents that include SEC filing metadata
- add regression tests covering default document titles and descriptions, along with a test helper to expose the backend package on the test path

## Testing
- not run (missing dependencies: llama_index, pydantic)


------
https://chatgpt.com/codex/tasks/task_e_68fe759ffe18832399e769dd3d3a5598