### PR TITLE
Fix Vercel build commands for frontend app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
-  "buildCommand": "npm run build",
-  "devCommand": "npm run dev",
-  "installCommand": "npm install",
+  "buildCommand": "cd frontend && npm run build",
+  "devCommand": "cd frontend && npm run dev",
+  "installCommand": "cd frontend && npm install",
   "framework": "nextjs",
-  "outputDirectory": ".next"
+  "outputDirectory": "frontend/.next"
 }


### PR DESCRIPTION
## Summary
- adjust Vercel install, dev, and build commands to run within the frontend workspace
- update the configured output directory to match the frontend Next.js build output

## Testing
- `npm --prefix frontend run build` *(fails: Sentry CLI requires network access through proxy and returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fe7bec6f488323997e408bf7fab747