### PR TITLE
Resolve Next.js Deployment Version Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:frontend": "npm --prefix frontend run build",
     "lint:frontend": "npm --prefix frontend run lint"
   },
-  "devDependencies": {
+  "dependencies": {
     "next": "^13.4.2"
   }
 }


### PR DESCRIPTION
Vercel requires Next.js to be in dependencies (not devDependencies) to properly detect the framework version during deployment.

Fixes:
- Error: No Next.js version detected
- Warning: Could not identify Next.js version

🤖 Generated with [Claude Code](https://claude.com/claude-code)