### PR TITLE
Harden vector setup and external integrations

### DIFF
--- a/backend/app/chat/engine.py
+++ b/backend/app/chat/engine.py
@@ -75,7 +75,11 @@ def fetch_and_read_document(
     with TemporaryDirectory() as temp_dir:
         temp_file_path = Path(temp_dir) / f"{str(document.id)}.pdf"
         with open(temp_file_path, "wb") as temp_file:
-            with requests.get(document.url, stream=True) as r:
+            with requests.get(
+                document.url,
+                stream=True,
+                timeout=(10, 30),
+            ) as r:
                 r.raise_for_status()
                 for chunk in r.iter_content(chunk_size=8192):
                     temp_file.write(chunk)

--- a/backend/app/chat/pg_vector.py
+++ b/backend/app/chat/pg_vector.py
@@ -45,7 +45,6 @@ class CustomPGVectorStore(PGVectorStore):
             async with session.begin():
                 statement = sqlalchemy.text("CREATE EXTENSION IF NOT EXISTS vector")
                 await session.execute(statement)
-                await session.commit()
 
         async with self._async_session() as session:
             async with session.begin():

--- a/backend/app/chat/tools.py
+++ b/backend/app/chat/tools.py
@@ -95,6 +95,7 @@ def get_polygon_io_sec_tool(document: DocumentSchema) -> FunctionTool:
     tool_metadata = get_tool_metadata_for_document(document)
 
     async def extract_data_from_sec_document(*args, **kwargs) -> List[str]:
+        client: AsyncReferenceClient | None = None
         try:
             client = ReferenceClient(
                 api_key=settings.POLYGON_IO_API_KEY,
@@ -130,6 +131,9 @@ def get_polygon_io_sec_tool(document: DocumentSchema) -> FunctionTool:
                 exc_info=True,
             )
             return ["No answer found."]
+        finally:
+            if client is not None:
+                await client.close()
 
     def sync_func_placeholder(*args, **kwargs) -> None:
         raise NotImplementedError(


### PR DESCRIPTION
## Summary
- avoid double-committing during async vector store setup to keep startup stable
- enforce timeouts when streaming SEC PDFs to avoid hanging workers
- close polygon.io reference clients after each call to release sockets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68feeaaffff88323a4b0680816b3c223